### PR TITLE
Introduce sending-academic-term-ewp-id & non-standard-mobility-period

### DIFF
--- a/endpoints/get-response.xsd
+++ b/endpoints/get-response.xsd
@@ -254,7 +254,10 @@
                                 supposed to take place *during* the academic term identified here.
 
                                 "During" doesn't imply that it will take place over the *entire* period of the
-                                academic term.
+                                academic term. However, it's also RECOMMENDED to supply the *smallest* academic
+                                term within which the mobility period fits into (i.e. the use of an academic
+                                year should be avoided if a semester is sufficient). See here:
+                                https://github.com/erasmus-without-paper/ewp-specs-api-omobilities/pull/30#discussion_r159843983
 
                                 Note, that sending and receiving HEIs MAY use different academic term
                                 identifiers (e.g. "2010/2011-1/2" might be equal to "2010/2010-2/2"). This

--- a/endpoints/get-response.xsd
+++ b/endpoints/get-response.xsd
@@ -230,11 +230,66 @@
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
+                <xs:choice minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Most mobilities take place (or are supposed to take place) during a single
+                            academic term (or part of such single term). The sending HEI is REQUIRED to
+                            either identify this term, or to clearly state that the sending mobility period
+                            is "non-standard", and is not contained by any single academic term.
+
+                            This information needs to be provided "from the start" (when a new nomination is
+                            created). It is different than the information provided in the
+                            `planned-arrival-date` and `planned-departure-date` elements (which may be
+                            provided at later date).
+
+                            For more information, read this thread:
+                            https://github.com/erasmus-without-paper/ewp-specs-types-academic-term/issues/2
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:element name="sending-academic-term-ewp-id" type="trm:EwpAcademicTermId">
+                        <xs:annotation>
+                            <xs:documentation>
+                                If this element is present, then the sending HEI states that the mobility is
+                                supposed to take place *during* the academic term identified here.
+
+                                "During" doesn't imply that it will take place over the *entire* period of the
+                                academic term.
+
+                                Note, that sending and receiving HEIs MAY use different academic term
+                                identifiers (e.g. "2010/2011-1/2" might be equal to "2010/2010-2/2"). This
+                                particular identifier is the term identifier at the *sending* HEI, not the
+                                receiving HEI.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="non-standard-mobility-period" type="ewp:Empty">
+                        <xs:annotation>
+                            <xs:documentation>
+                                If this element is present, then the sending HEI states that the mobility is
+                                supposed to take place outside the bounds of any standard academic term. E.g.
+                                during the summer vacations.
+
+                                This element is currently empty, but this MAY change in the future. Clients
+                                MUST be ready for that (and treat such non-empty element as if it was empty).
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:choice>
                 <xs:element name="receiving-academic-year-id" type="trm:AcademicYearId" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             Academic year during which this mobility takes place (or is supposed to take
                             place).
+
+                            Note, that sending and receiving HEIs MAY use different academic year
+                            identifiers (e.g. "2010/2011" vs. "2010/2010" or "2011/2011"). This
+                            particular identifier is the year identifier at the *receiving* HEI, not the
+                            sending HEI.
+
+                            This means that the sending HEI MUST know how the receiving HEI identifies its
+                            academic years (i.e. whether it lies on the northern or southern hemisphere),
+                            and be able to match its mobilities with these identifiers.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>


### PR DESCRIPTION
Fix https://github.com/erasmus-without-paper/ewp-specs-types-academic-term/issues/2
(based on Solution 5)